### PR TITLE
[refactor]タスク期限のデフォルト期限生成機能をリファクタリング

### DIFF
--- a/src/main/kotlin/com/example/domain/model/task/entity/Task.kt
+++ b/src/main/kotlin/com/example/domain/model/task/entity/Task.kt
@@ -4,7 +4,6 @@ import com.example.domain.model.task.value_object.DueDate
 import com.example.domain.model.task.value_object.TaskId
 import com.example.domain.model.task.value_object.TaskName
 import com.example.domain.model.task.value_object.TaskStatus
-import java.time.LocalDate
 
 class Task private constructor(
     val taskId: TaskId,
@@ -26,7 +25,7 @@ class Task private constructor(
          */
         fun create(
             taskName: TaskName,
-            dueDate: DueDate = DueDate.valueOf(LocalDate.now())
+            dueDate: DueDate = DueDate.createDefault()
         ): Task =
             Task(
                 TaskId.generate(),

--- a/src/main/kotlin/com/example/domain/model/task/value_object/DueDate.kt
+++ b/src/main/kotlin/com/example/domain/model/task/value_object/DueDate.kt
@@ -30,9 +30,16 @@ class DueDate private constructor(val value: LocalDate) : ValueObject<LocalDate>
                     ?.let { DueDate(it) }
                     ?: throw TaskInvalidRequestException("DueDate($value) must be after today.")
             } else {
-                DueDate(LocalDate.now())
+                this.createDefault()
             }
         }
+
+        /**
+         * タスク期限日が当日のタスク期限を作成する。
+         *
+         * @return 当日の値を持つタスク期限日
+         */
+        fun createDefault(): DueDate = DueDate(LocalDate.now())
 
         fun reconstruct(value: LocalDate): DueDate = DueDate(value)
     }


### PR DESCRIPTION
「当日をデフォルト期限としてオブジェクト生成」の機能がタスク期限の値オブジェクトと、タスクエンティティの両方に重複して存在したため、デフォルト期限生成メソッドとして切り出し。