### PR TITLE
[add]タスク更新機能の追加

### DIFF
--- a/src/main/kotlin/com/example/controller/TaskController.kt
+++ b/src/main/kotlin/com/example/controller/TaskController.kt
@@ -1,6 +1,7 @@
 package com.example.controller
 
 import com.example.controller.request.CreateTaskRequest
+import com.example.controller.request.UpdateTaskRequest
 import com.example.usecase.TaskUseCase
 import com.example.usecase.dto.TaskUseCaseDto
 import io.ktor.application.*
@@ -28,6 +29,9 @@ fun Route.taskController() {
 
     post("/task") {
         val body = call.receive<CreateTaskRequest>()
+
+        requireNotNull(body.name) {"タスク名は必須項目です。"}
+
         val taskUseCaseDto = TaskUseCaseDto(
             name = body.name,
             dueDate = body.duedate
@@ -35,6 +39,22 @@ fun Route.taskController() {
 
         taskUseCase.create(taskUseCaseDto)
         call.respond("The task is created.")
+    }
+
+    put("/task/{taskId}") {
+        // パスパラメータを指定しないパス(/task/)場合、以下のIllegalArgumentExceptionではなく、404 NotFoundとなる。
+        val pathParameter = call.parameters["taskId"] ?: throw IllegalArgumentException("Path parameter is null.")
+
+        val body = call.receive<UpdateTaskRequest>()
+        val taskUseCaseDto = TaskUseCaseDto(
+            pathParameter,
+            body.name,
+            body.status,
+            body.dueDate
+        )
+
+        taskUseCase.update(taskUseCaseDto)
+        call.respond("The task is updated.")
     }
 
     delete("/task/{taskId}") {

--- a/src/main/kotlin/com/example/controller/request/UpdateTaskRequest.kt
+++ b/src/main/kotlin/com/example/controller/request/UpdateTaskRequest.kt
@@ -1,0 +1,9 @@
+package com.example.controller.request
+
+import java.time.LocalDate
+
+data class UpdateTaskRequest(
+    val name: String? = null,
+    val status: String? = null,
+    val dueDate: LocalDate? = null
+)

--- a/src/main/kotlin/com/example/domain/model/task/entity/Task.kt
+++ b/src/main/kotlin/com/example/domain/model/task/entity/Task.kt
@@ -91,6 +91,13 @@ class Task private constructor(
             dueDate
         )
 
+    fun changeStatus(changedStatus: TaskStatus): Task = Task(
+        taskId,
+        taskName,
+        changedStatus,
+        dueDate
+    )
+
     /**
      * タスク期限を変更する。
      *

--- a/src/main/kotlin/com/example/domain/repository/TaskRepository.kt
+++ b/src/main/kotlin/com/example/domain/repository/TaskRepository.kt
@@ -15,4 +15,6 @@ interface TaskRepository {
     fun save(task: Task)
 
     fun remove(taskId: TaskId)
+    
+    fun update(task: Task)
 }

--- a/src/main/kotlin/com/example/infrastructure/repository/TaskJdbiRepository.kt
+++ b/src/main/kotlin/com/example/infrastructure/repository/TaskJdbiRepository.kt
@@ -36,4 +36,16 @@ interface TaskJdbiRepository : SqlObject {
         where id = :taskId
     """)
     fun delete(taskId: String)
+
+    @SqlUpdate("""
+        update
+        tasks
+        set 
+            name = :taskRepositoryDto.taskName,
+            status = :taskRepositoryDto.taskStatus,
+            duedate = :taskRepositoryDto.dueDate
+        where
+        Id = :taskRepositoryDto.taskId
+    """)
+    fun update(taskRepositoryDto: TaskRepositoryDto)
 }

--- a/src/main/kotlin/com/example/infrastructure/repository/TaskRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/infrastructure/repository/TaskRepositoryImpl.kt
@@ -31,4 +31,9 @@ class TaskRepositoryImpl : TaskRepository {
     override fun remove(taskId: TaskId) {
         return dao.delete(taskId.value())
     }
+
+    override fun update(task: Task) {
+        val taskRepositoryDto = TaskRepositoryDto.domainToRecord(task)
+        return dao.update(taskRepositoryDto)
+    }
 }

--- a/src/main/kotlin/com/example/usecase/TaskUseCase.kt
+++ b/src/main/kotlin/com/example/usecase/TaskUseCase.kt
@@ -1,6 +1,9 @@
 package com.example.usecase
 
+import com.example.domain.model.task.value_object.DueDate
 import com.example.domain.model.task.value_object.TaskId
+import com.example.domain.model.task.value_object.TaskName
+import com.example.domain.model.task.value_object.TaskStatus
 import com.example.infrastructure.repository.TaskRepositoryImpl
 import com.example.usecase.dto.TaskUseCaseDto
 
@@ -25,5 +28,32 @@ class TaskUseCase {
 
     fun remove(taskId: String) {
         taskRepository.remove(TaskId.valueOf(taskId))
+    }
+
+    fun update(taskUseCaseDto: TaskUseCaseDto) {
+        val taskId = taskUseCaseDto.id?.let { TaskId.valueOf(it) }
+
+        val currentTask = taskId
+            ?.let { taskRepository.findById(it) }
+            ?: throw java.lang.IllegalArgumentException("タスクIDが不正です。")
+
+        val changedTaskName = taskUseCaseDto.name
+            ?.let { TaskName.valueOf(it) }
+            ?: currentTask.taskName
+
+        val changedTaskStatus = taskUseCaseDto.status
+            ?.let { TaskStatus.valueOf(it) }
+            ?: currentTask.taskStatus
+
+        val changedDueDate = taskUseCaseDto.dueDate
+            ?.let { DueDate.valueOf(it) }
+            ?: currentTask.dueDate
+
+        val changedTask = currentTask
+            .changeName(changedTaskName)
+            .changeStatus(changedTaskStatus)
+            .changeDueDate(changedDueDate)
+
+        taskRepository.update(changedTask)
     }
 }

--- a/src/main/kotlin/com/example/usecase/dto/TaskUseCaseDto.kt
+++ b/src/main/kotlin/com/example/usecase/dto/TaskUseCaseDto.kt
@@ -7,15 +7,19 @@ import java.time.LocalDate
 
 data class TaskUseCaseDto(
     val id: String? = null,
-    val name: String,
+    val name: String? = null,
     val status: String? = null,
     val dueDate: LocalDate? = null
 ) {
 
-    fun createDomain(): Task = Task.create(
-        TaskName.valueOf(name),
-        DueDate.valueOf(dueDate)
-    )
+    fun createDomain(): Task {
+        requireNotNull(name) {"タスク名は必須項目です。"}
+
+        return Task.create(
+            TaskName.valueOf(name),
+            DueDate.valueOf(dueDate)
+        )
+    }
 
     companion object {
         fun domainToDto(task: Task): TaskUseCaseDto = TaskUseCaseDto(

--- a/src/test/kotlin/com/example/controller/TaskControllerKtTest.kt
+++ b/src/test/kotlin/com/example/controller/TaskControllerKtTest.kt
@@ -1,8 +1,12 @@
 package com.example.controller
 
 import com.example.controller.request.CreateTaskRequest
+import com.example.controller.request.UpdateTaskRequest
 import com.example.controller.response.FindAllTasksResponse
 import com.example.controller.response.FindTaskByIdResponse
+import com.example.domain.model.task.value_object.DueDate
+import com.example.domain.model.task.value_object.TaskName
+import com.example.domain.model.task.value_object.TaskStatus
 import com.example.infrastructure.framework.configureRouting
 import com.example.infrastructure.framework.configureSerialization
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -11,6 +15,7 @@ import io.ktor.http.*
 import io.ktor.server.testing.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 internal class TaskControllerKtTest {
 
@@ -90,4 +95,66 @@ internal class TaskControllerKtTest {
 
         }
     }
+
+    @Test
+    fun `タスクの更新ができること`() {
+        val mapper = jacksonObjectMapper()
+        mapper.findAndRegisterModules()
+
+        withTestApplication({
+            configureRouting()
+            configureSerialization()
+        }) {
+
+            handleRequest(HttpMethod.Post, "/task") {
+                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+                val createTaskRequest = CreateTaskRequest(
+                    "タスク２"
+                )
+
+                val createTaskRequestJsonBody = mapper.writeValueAsString(createTaskRequest)
+                setBody(createTaskRequestJsonBody)
+            }
+
+            val taskIds: List<String>
+            handleRequest(HttpMethod.Get, "/tasks").apply {
+                val findAllTasksResponse = mapper.readValue<List<FindAllTasksResponse>>(response.content!!)
+                taskIds = findAllTasksResponse
+                    .map { it.id }
+            }
+
+            val updatedTaskName = TaskName.valueOf("タスク２")
+            val updatedTaskStatus = TaskStatus.DONE
+            val updatedDueDate = DueDate.valueOf(LocalDate.now().plusDays(1))
+
+            handleRequest(HttpMethod.Put,"/task/${taskIds[0]}") {
+                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+                val updateTaskRequest = UpdateTaskRequest(
+                    name = updatedTaskName.value(),
+                    status = updatedTaskStatus.toString(),
+                    dueDate = updatedDueDate.value()
+                )
+
+                val updateTaskRequestBody = mapper.writeValueAsString(updateTaskRequest)
+                setBody(updateTaskRequestBody)
+            }.apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                assertEquals("The task is updated.", response.content)
+            }
+
+            handleRequest(HttpMethod.Get, "/task/${taskIds[0]}").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+
+                val findTaskByIdResponse = mapper.readValue<FindTaskByIdResponse>(response.content!!)
+                assertEquals(updatedTaskName.value(), findTaskByIdResponse.name)
+                assertEquals(updatedTaskStatus.toString(), findTaskByIdResponse.status)
+                assertEquals(updatedDueDate.value().toString(), findTaskByIdResponse.dueDate.toString())
+            }
+
+                handleRequest(HttpMethod.Delete, "/task/${taskIds[0]}")
+            }
+
+        }
 }

--- a/src/test/kotlin/com/example/controller/TaskControllerKtTest.kt
+++ b/src/test/kotlin/com/example/controller/TaskControllerKtTest.kt
@@ -68,7 +68,7 @@ internal class TaskControllerKtTest {
                 assertEquals(HttpStatusCode.OK, response.status())
 
                 val findTaskByIdResponse = mapper.readValue<FindTaskByIdResponse>(response.content!!)
-                assertTrue(findTaskByIdResponse.name != null)
+                assertTrue(findTaskByIdResponse.name != "")
             }
 
             handleRequest(HttpMethod.Delete, "/task/${taskIds[0]}").apply {

--- a/src/test/kotlin/com/example/controller/TaskControllerKtTest.kt
+++ b/src/test/kotlin/com/example/controller/TaskControllerKtTest.kt
@@ -18,6 +18,7 @@ internal class TaskControllerKtTest {
     fun `タスクの作成、取得、削除ができること`() {
 
         val mapper = jacksonObjectMapper()
+        mapper.findAndRegisterModules()
 
         withTestApplication({
             configureRouting()

--- a/src/test/kotlin/com/example/controller/TaskControllerKtTest.kt
+++ b/src/test/kotlin/com/example/controller/TaskControllerKtTest.kt
@@ -28,7 +28,7 @@ internal class TaskControllerKtTest {
                 addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
 
                 val createTaskRequest = CreateTaskRequest(
-                    name = "タスク１"
+                    "タスク１"
                 )
 
                 val createTaskJsonBody = mapper.writeValueAsString(createTaskRequest)

--- a/src/test/kotlin/com/example/domain/model/task/entity/TaskTest.kt
+++ b/src/test/kotlin/com/example/domain/model/task/entity/TaskTest.kt
@@ -90,6 +90,14 @@ internal class TaskTest {
     }
 
     @Test
+    fun `生成したタスクの状態を変更できること`() {
+        val task = TaskTestFactory.create()
+        val changedTask = task.changeStatus(TaskStatus.DONE)
+
+        assertEquals(TaskStatus.DONE, changedTask.taskStatus)
+    }
+
+    @Test
     fun `生成したタスクの期限を変更できること`() {
         val task = TaskTestFactory.create()
 


### PR DESCRIPTION
本来は修正内容ごとにプルリクを分けるべきだが、レビュワーはいないため、単一のプルリクで処理する。