### PR TITLE
[refactor]JDBIプラグインの適応方法の改善

### DIFF
--- a/src/main/kotlin/com/example/infrastructure/repository/PostgresDatabaseFactory.kt
+++ b/src/main/kotlin/com/example/infrastructure/repository/PostgresDatabaseFactory.kt
@@ -1,12 +1,17 @@
 package com.example.infrastructure.repository
 
 import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.kotlin.KotlinPlugin
+import org.jdbi.v3.postgres.PostgresPlugin
+import org.jdbi.v3.sqlobject.kotlin.KotlinSqlObjectPlugin
 import org.koin.core.component.KoinComponent
 
 class PostgresDatabaseFactory(val dataSource: DataSource) : DatabaseFactory, KoinComponent {
     override fun connect(): Jdbi {
 
         return Jdbi.create(dataSource.url, dataSource.username, dataSource.password)
-            .installPlugins()
+            .installPlugin(KotlinPlugin())
+            .installPlugin(KotlinSqlObjectPlugin())
+            .installPlugin(PostgresPlugin())
     }
 }


### PR DESCRIPTION
JDBIのinstallPluginについて、installPlugins()による自動インストールではなく、installPlugin()による明示的なインストールに修正。 （公式ドキュメント上は後者が望ましいとされているため）